### PR TITLE
Add Harvard Business Review

### DIFF
--- a/LIST.md
+++ b/LIST.md
@@ -64,6 +64,7 @@
 - [Golf Porcelaine](http://www.golf-porcelaine.com/404notfound)
 - [Google](https://www.google.com/404)
 - [Hakin.se](http://lab.hakim.se/404/)
+- [Harvard Business Review](https://hbr.org/404)
 - [Home Star Runners](http://www.homestarrunner.com/random_garbage_text)
 - [Huml](https://www.huml.org/404.shtml)
 - [IBM](https://www.ibm.com/404)


### PR DESCRIPTION
The 404 page is pretty cool with a cartoon. I've added a screenshot of the 404 page here:

<img width="588" alt="hbr-404" src="https://user-images.githubusercontent.com/15604207/96367346-e8d93580-117f-11eb-940e-cd77cbe3346d.png">